### PR TITLE
Fix regex for hex codes and tweak stop message

### DIFF
--- a/R/contrast.R
+++ b/R/contrast.R
@@ -27,10 +27,10 @@ cr_get_ratio <- function(col_1, col_2, quiet = FALSE, view = FALSE) {
   if(
     (!grepl("^#", col_1) & !col_1 %in% grDevices::colors() |
      !grepl("^#", col_2) & !col_2 %in% grDevices::colors()) |
-    (grepl("^#", col_1) & !grepl("^#\\w{6}$", col_1) |
-     grepl("^#", col_2) & !grepl("^#\\w{6}$", col_2))
+    (grepl("^#", col_1) & !grepl("^#[0-9a-fA-F]{6}$", col_1) |
+     grepl("^#", col_2) & !grepl("^#[0-9a-fA-F]{6}$", col_2))
   ) {
-    stop("Inputs must match colors() if named, or the hex form #RRGGBB.\n")
+    stop('Inputs must be in colors() if named, or of the hex form "#RRGGBB".\n')
   }
 
   if (class(quiet) != "logical") {

--- a/R/contrast.R
+++ b/R/contrast.R
@@ -169,10 +169,10 @@ cr_view_contrast <- function(col_1, col_2) {
   if(
     (!grepl("^#", col_1) & !col_1 %in% grDevices::colors() |
      !grepl("^#", col_2) & !col_2 %in% grDevices::colors()) |
-    (grepl("^#", col_1) & !grepl("^#\\w{6}$", col_1) |
-     grepl("^#", col_2) & !grepl("^#\\w{6}$", col_2))
+    (grepl("^#", col_1) & !grepl("^#[0-9a-fA-F]{6}$", col_1) |
+     grepl("^#", col_2) & !grepl("^#[0-9a-fA-F]{6}$", col_2))
   ) {
-    stop("Inputs must match colors() if named, or the hex form #RRGGBB.\n")
+    stop('Inputs must be in colors() if named, or of the hex form "#RRGGBB".\n')
   }
 
   # Reduce plot margins


### PR DESCRIPTION
Hi Matt. 

Thanks for this great package! It's a really helpful utility.

I noticed that the regex for checking hex codes is a little lax - it allows for letters other than A-F and a-f. This PR provides a fix for that. I also slightly tweaked the stop message to make it clear that the hex code needs to be in "", something I keep forgetting to do myself!